### PR TITLE
Fix PR status command and add post-merge workflow rules

### DIFF
--- a/.claude/rules/gh-pr-always-update-description-after-new-commits.rule.md
+++ b/.claude/rules/gh-pr-always-update-description-after-new-commits.rule.md
@@ -1,0 +1,168 @@
+---
+applies_to:
+  - file_patterns: []
+  - contexts: ["gh", "github", "pr", "push", "updates"]
+  - actions: ["after_push_to_branch_with_open_pr"]
+timing: "after"
+summary: "Always update PR description when pushing new work to branch with open PR, if changes warrant it"
+version: "1.0.0"
+---
+
+# Rule: Always Update PR Description After New Commits
+
+<purpose>
+This rule ensures that pull request descriptions remain accurate and comprehensive when new commits are pushed to a branch with an open PR, keeping reviewers informed about additional work and changes to the scope or approach.
+</purpose>
+
+<instructions>
+After pushing commits to a branch that has an open pull request, you MUST:
+
+1. **Check if PR exists**: Use `gh pr list` or `gh pr view` to confirm there's an open PR for the current branch
+2. **Analyze new commits**: Review what work was added since the last PR description update
+3. **Evaluate description sufficiency**: Determine if current description covers the new work adequately
+4. **Update if needed**: If new work changes scope, approach, or adds significant functionality, update the PR description
+5. **Leave unchanged if sufficient**: If existing description already covers the new work, no update needed
+
+This applies when:
+- New commits are pushed to a branch with an open PR
+- The new work substantially changes or expands the PR scope
+- The existing description doesn't adequately reflect the current state of work
+</instructions>
+
+<evaluation_criteria>
+**Update PR description when new commits include:**
+- New features or functionality not mentioned in original description
+- Significant changes to the implementation approach
+- Additional bug fixes beyond the original scope
+- New files or components not covered in the original description
+- Changes that affect the verification steps or testing approach
+- Work that addresses additional requirements or edge cases
+
+**Leave description unchanged when new commits are:**
+- Minor fixes or improvements already implied by the original description
+- Refactoring that doesn't change the external behavior
+- Code cleanup or formatting changes
+- Small bug fixes that are part of the expected implementation
+- Test additions that were already mentioned in verification steps
+- Documentation updates for features already described
+</evaluation_criteria>
+
+<workflow_steps>
+After pushing to branch with open PR:
+
+1. **Check for open PR**: `gh pr view` (no arguments uses current branch)
+2. **Review new commits**: `git log --oneline [last-described-commit]..HEAD`
+3. **Assess current description**: Read existing PR description
+4. **Determine if update needed**: Apply evaluation criteria
+5. **Update if warranted**: `gh pr edit --body "updated description"`
+6. **Skip if sufficient**: Continue with normal workflow
+</workflow_steps>
+
+<update_approaches>
+**For significant additions:**
+- Add new sections to Purpose or Approach sections
+- Update verification steps if new testing is required
+- Mention new files or components in Approach section
+- Add any new open questions or considerations
+
+**For scope changes:**
+- Update Purpose section to reflect expanded scope
+- Revise Approach section with new implementation details
+- Update verification steps with additional testing requirements
+- Note any changes to timeline or complexity
+
+**For approach changes:**
+- Revise Approach section with new technical decisions
+- Update any affected verification steps
+- Note reasons for approach changes in Additional Notes
+- Update any relevant open questions
+</update_approaches>
+
+<examples>
+<update_warranted>
+Original PR: "Add user authentication"
+New commits: Added OAuth integration, password reset functionality
+Action: Update description to include OAuth and password reset features
+
+Original PR: "Fix date formatting bug"
+New commits: Also fixed timezone handling and added comprehensive date tests  
+Action: Update description to reflect expanded bug fix scope
+
+Original PR: "Refactor user service"
+New commits: Changed from REST to GraphQL API approach
+Action: Update Approach section to explain GraphQL decision
+</update_warranted>
+
+<update_not_needed>
+Original PR: "Add user profile component with avatar and bio"
+New commits: Fixed CSS spacing, added hover effects
+Action: No update needed - improvements are implied by original description
+
+Original PR: "Implement search functionality with filters"
+New commits: Added unit tests for search filters
+Action: No update needed - testing was mentioned in verification steps
+
+Original PR: "Fix login validation errors"
+New commits: Improved error messages, added input sanitization
+Action: No update needed - improvements are part of expected fix scope
+</update_not_needed>
+</examples>
+
+<commands>
+**Check for open PR on current branch:**
+```bash
+gh pr view
+```
+
+**Check PR status across branches:**
+```bash
+gh pr list --state open
+```
+
+**Review recent commits:**
+```bash
+git log --oneline -10
+git log --oneline [last-update]..HEAD
+```
+
+**Update PR description:**
+```bash
+gh pr edit --body "updated description content"
+```
+
+**Update PR description interactively:**
+```bash
+gh pr edit
+```
+</commands>
+
+<validation>
+Before and after PR description updates, verify:
+- [ ] Open PR exists for the current branch
+- [ ] New commits have been analyzed for scope/approach changes
+- [ ] Current description has been evaluated for adequacy
+- [ ] Update decision follows the evaluation criteria
+- [ ] If updated, new description accurately reflects all current work
+- [ ] If not updated, existing description still covers new commits appropriately
+</validation>
+
+<description_update_format>
+When updating descriptions, maintain the standard 5-section format:
+- **Purpose**: Update if scope has expanded or changed
+- **Approach**: Update if implementation strategy has changed  
+- **Additional Notes**: Add notes about new decisions or changes
+- **Open Questions**: Update or add new questions if applicable
+- **Verification Steps**: Add new steps for additional functionality
+
+Preserve existing content that remains accurate and only modify sections that need updates.
+</description_update_format>
+
+<exceptions>
+Do NOT update PR descriptions when:
+- No open PR exists for the current branch
+- New commits are purely cosmetic (formatting, comments)
+- Changes are minor fixes clearly implied by original description
+- User explicitly requests to keep current description
+- PR is in draft state and user is still actively developing
+- Description was recently updated and still accurately reflects all work
+</exceptions>

--- a/.claude/rules/gh-pr-always-verify-approval-before-merge.rule.md
+++ b/.claude/rules/gh-pr-always-verify-approval-before-merge.rule.md
@@ -22,7 +22,7 @@ Before merging any pull request, you MUST verify BOTH conditions:
 
 Verification steps:
 1. CHECK that human has clearly stated "approved" or "merge this PR"
-2. RUN `gh pr status [PR-number]` to check GitHub approval status
+2. RUN `gh pr view [PR-number]` to check GitHub approval status
 3. CONFIRM both approvals exist before proceeding with merge
 4. ONLY merge when both conditions are satisfied
 
@@ -37,7 +37,7 @@ If either condition is missing, do NOT merge.
 - "LGTM, merge it"
 
 **GitHub Status Check:**
-Use `gh pr status [PR-number]` to verify:
+Use `gh pr view [PR-number]` to verify:
 - PR shows as "approved" in status
 - All required checks are passing
 - No blocking reviews or requests for changes
@@ -50,16 +50,16 @@ Use `gh pr status [PR-number]` to verify:
 
 <examples>
 <correct>
-Human says "PR #1 is approved" AND gh pr status shows approved:
+Human says "PR #1 is approved" AND gh pr view shows approved:
 ```bash
-gh pr status 1
+gh pr view 1
 # Output shows: ✓ Approved by reviewers
 # Safe to proceed with merge
 ```
 
 Human says "Please merge the authentication PR" AND GitHub shows approval:
 ```bash
-gh pr status 1
+gh pr view 1
 # Output shows: ✓ All checks passed, ✓ Approved
 # Safe to proceed with merge
 ```
@@ -75,7 +75,7 @@ Human: "This PR looks good, merge it"
 
 Only GitHub approval:
 ```bash
-gh pr status 1
+gh pr view 1
 # Output: ✓ Approved
 # Missing: Explicit human approval statement
 # Action: Do NOT merge, wait for human approval
@@ -91,14 +91,14 @@ Human: "The code looks fine"
 </examples>
 
 <verification_commands>
-Check PR status:
-```bash
-gh pr status [PR-number]
-```
-
-Check specific PR details:
+Check specific PR details and approval status:
 ```bash
 gh pr view [PR-number]
+```
+
+Check general PR status (no PR number argument):
+```bash
+gh pr status
 ```
 
 List all PRs with status:

--- a/.claude/rules/gh-pr-verification-only-include-human-required-steps.rule.md
+++ b/.claude/rules/gh-pr-verification-only-include-human-required-steps.rule.md
@@ -1,0 +1,154 @@
+---
+applies_to:
+  - file_patterns: []
+  - contexts: ["gh", "github", "pr", "verification", "testing"]
+  - actions: ["writing_pr_verification_section"]
+timing: "before"
+summary: "Only include verification steps that require human interaction or judgment that AI cannot perform"
+version: "1.0.0"
+---
+
+# Rule: Only Include Human-Required Verification Steps
+
+<purpose>
+This rule ensures that PR verification steps only contain items that genuinely require human interaction, testing, or judgment that Claude cannot perform automatically, making the verification section meaningful and actionable for human reviewers.
+</purpose>
+
+<instructions>
+When writing verification steps in PR descriptions, ONLY include items that require:
+
+1. **Manual user interaction**: Clicking buttons, navigating UI, testing user flows
+2. **Subjective human judgment**: Visual design assessment, user experience evaluation
+3. **External system testing**: Testing against live APIs, databases, or services Claude cannot access
+4. **Physical device testing**: Mobile devices, different browsers, hardware-specific features
+5. **End-to-end user workflows**: Complete business processes that span multiple systems
+6. **Security or privacy validation**: Manual review of sensitive data handling
+
+**EXCLUDE verification steps that Claude can check automatically:**
+- Command syntax correctness
+- File existence or creation
+- Code compilation or build success
+- Rule indexing and discovery
+- Git workflow execution
+- Basic functionality that can be tested programmatically
+</instructions>
+
+<human_required_examples>
+**Include these types of verification steps:**
+- [ ] Test login flow works correctly in production environment
+- [ ] Verify mobile responsive design displays properly on various screen sizes
+- [ ] Confirm email notifications are received and formatted correctly
+- [ ] Test payment processing with real payment provider
+- [ ] Validate accessibility with screen reader software
+- [ ] Review UI changes meet design system standards
+- [ ] Test user registration flow end-to-end
+- [ ] Verify API rate limiting works as expected under load
+- [ ] Confirm data backup and recovery procedures work
+- [ ] Test SSO integration with company identity provider
+</human_required_examples>
+
+<claude_can_check_examples>
+**EXCLUDE these types (Claude can verify automatically):**
+- ❌ Command syntax fix resolves the error
+- ❌ New files appear in correct directories
+- ❌ Rules show up in rule index
+- ❌ Code compiles without errors
+- ❌ Tests pass successfully
+- ❌ Git workflow executes properly
+- ❌ Configuration files are valid
+- ❌ Documentation is updated
+- ❌ Version numbers are correct
+- ❌ File structure follows conventions
+</claude_can_check_examples>
+
+<evaluation_criteria>
+Ask yourself for each verification step:
+- **Can Claude test this?** If yes, exclude it
+- **Does this require human senses?** (seeing, hearing, feeling) → Include
+- **Does this require external access Claude doesn't have?** → Include  
+- **Does this require subjective judgment?** → Include
+- **Does this require physical interaction?** → Include
+- **Is this a user-facing feature that needs real user testing?** → Include
+
+If the answer to all questions is "no", then Claude can likely verify it automatically.
+</evaluation_criteria>
+
+<good_verification_sections>
+**For UI/UX changes:**
+```
+## Verification Steps
+- [ ] Test responsive design on mobile devices (iOS/Android)
+- [ ] Verify color contrast meets WCAG accessibility standards
+- [ ] Confirm new component integrates well with existing design system
+- [ ] Test user flow with actual users to ensure intuitiveness
+```
+
+**For API changes:**
+```
+## Verification Steps  
+- [ ] Test API endpoints work correctly in staging environment
+- [ ] Verify third-party integrations still function properly
+- [ ] Confirm rate limiting doesn't impact legitimate usage patterns
+- [ ] Test error handling with production-like data volumes
+```
+
+**For backend changes:**
+```
+## Verification Steps
+- [ ] Monitor performance impact in production environment
+- [ ] Verify database migrations complete successfully on production data
+- [ ] Test backup and recovery procedures with new schema changes
+- [ ] Confirm monitoring and alerting capture relevant metrics
+```
+</good_verification_sections>
+
+<bad_verification_sections>
+**Too many Claude-verifiable items:**
+```
+## Verification Steps
+- [ ] Code compiles without errors  ❌ (Claude can check)
+- [ ] New functions are exported properly  ❌ (Claude can check)
+- [ ] Tests pass successfully  ❌ (Claude can check)  
+- [ ] Documentation is updated  ❌ (Claude can check)
+- [ ] File permissions are set correctly  ❌ (Claude can check)
+```
+
+**Better version:**
+```
+## Verification Steps
+- [ ] Test feature works correctly in staging environment
+- [ ] Verify performance is acceptable under realistic load
+```
+</bad_verification_sections>
+
+<special_cases>
+**For pure code/infrastructure changes with no user-facing impact:**
+- May legitimately have few or no verification steps
+- Focus on production environment testing
+- Include monitoring and performance validation
+- Consider: "No manual verification required - changes are internal"
+
+**For rule/automation changes:**
+- Avoid listing rule discovery or indexing
+- Focus on real-world effectiveness of the automation
+- Include edge case testing that requires human judgment
+</special_cases>
+
+<validation>
+Before finalizing verification steps, check:
+- [ ] Each step requires human interaction or access Claude doesn't have
+- [ ] Steps focus on user-facing functionality or production environment testing
+- [ ] No steps that Claude could verify automatically are included
+- [ ] Steps are specific and actionable for the reviewer
+- [ ] Section provides genuine value for quality assurance
+</validation>
+
+<empty_verification_acceptable>
+It's acceptable to have minimal or no verification steps when:
+- Changes are purely internal/infrastructure
+- All functionality can be automatically tested
+- No user-facing changes exist
+- No external integrations are affected
+
+In such cases, state explicitly: "No manual verification required - changes are internal and automatically testable."
+</empty_verification_acceptable>

--- a/.claude/rules/git-commits-always-set-claude-hughes-as-committer.rule.md
+++ b/.claude/rules/git-commits-always-set-claude-hughes-as-committer.rule.md
@@ -1,0 +1,168 @@
+---
+applies_to:
+  - file_patterns: []
+  - contexts: ["git", "commits", "identity", "committer"]
+  - actions: ["before_commit"]
+timing: "before"
+summary: "Always set git committer identity to Claude Hughes before any commit operations"
+version: "1.0.0"
+---
+
+# Rule: Always Set Claude Hughes as Committer
+
+<purpose>
+This rule ensures that git commits show Claude Hughes as both the author and committer, providing consistent identity attribution in GitHub and git history by setting the proper git configuration before committing.
+</purpose>
+
+<instructions>
+Before EVERY git commit operation, you MUST:
+
+1. **Set git committer identity**: Configure git user.name and user.email to Claude Hughes
+2. **Use consistent commit command**: Continue using --author flag for completeness
+3. **Verify identity**: Ensure both author and committer will show as Claude Hughes
+
+Commands to run before each commit:
+```bash
+git config user.name "Claude Hughes"
+git config user.email "doug+ai@doughughes.net"
+```
+
+Then commit with author flag as usual:
+```bash
+git commit --author="Claude Hughes <doug+ai@doughughes.net>" -m "commit message"
+```
+
+This ensures both the committer (from git config) and author (from --author flag) are set to Claude Hughes.
+</instructions>
+
+<identity_configuration>
+**Required git configuration:**
+- **Name**: "Claude Hughes"
+- **Email**: "doug+ai@doughughes.net"
+- **Scope**: Repository-local (not global to avoid affecting other projects)
+
+**Commands to execute:**
+```bash
+# Set repository-local git identity before commits
+git config user.name "Claude Hughes"
+git config user.email "doug+ai@doughughes.net"
+
+# Then commit with author flag for consistency
+git commit --author="Claude Hughes <doug+ai@doughughes.net>" -m "message"
+```
+</identity_configuration>
+
+<commit_workflow>
+**Complete commit workflow:**
+
+1. **Configure identity**: Set git config for committer
+2. **Stage files**: Add files with `git add`
+3. **Create commit**: Use commit command with author flag
+4. **Verify identity**: Both author and committer should be Claude Hughes
+
+**Before each commit:**
+```bash
+git config user.name "Claude Hughes"
+git config user.email "doug+ai@doughughes.net"
+git add [files]
+git commit --author="Claude Hughes <doug+ai@doughughes.net>" -m "message"
+```
+</commit_workflow>
+
+<github_display>
+**Expected GitHub display:**
+- **Author**: Claude Hughes (from --author flag)
+- **Committer**: Claude Hughes (from git config)
+- **GitHub user**: claude-hughes (based on SSH key association)
+
+This ensures consistent attribution across all git interfaces and GitHub displays.
+</github_display>
+
+<examples>
+<correct>
+Proper commit sequence:
+```bash
+git config user.name "Claude Hughes"
+git config user.email "doug+ai@doughughes.net"
+git add src/component.tsx
+git commit --author="Claude Hughes <doug+ai@doughughes.net>" -m "Add new component"
+# Result: Both author and committer show as Claude Hughes
+```
+
+After configuration, subsequent commits:
+```bash
+# Config persists for repository
+git add tests/component.test.tsx
+git commit --author="Claude Hughes <doug+ai@doughughes.net>" -m "Add component tests"
+# Result: Consistent Claude Hughes attribution
+```
+</correct>
+
+<incorrect>
+Committing without setting git config:
+```bash
+# Missing git config setup
+git commit --author="Claude Hughes <doug+ai@doughughes.net>" -m "Add feature"
+# Result: Author=Claude Hughes, Committer=dhughes (inconsistent)
+```
+
+Setting global config instead of local:
+```bash
+git config --global user.name "Claude Hughes"  # Affects all repos
+git commit --author="Claude Hughes <doug+ai@doughughes.net>" -m "Add feature"
+# Problem: Changes global git config for all projects
+```
+</incorrect>
+</examples>
+
+<verification>
+**Check git configuration:**
+```bash
+git config user.name     # Should return: Claude Hughes
+git config user.email    # Should return: doug+ai@doughughes.net
+```
+
+**Check recent commit attribution:**
+```bash
+git log --format="%an <%ae> | %cn <%ce>" -1
+# Should show: Claude Hughes <doug+ai@doughughes.net> | Claude Hughes <doug+ai@doughughes.net>
+```
+</verification>
+
+<persistence>
+**Git config persistence:**
+- Configuration is set per repository (not global)
+- Persists for all subsequent commits in this repository
+- Does not affect other git repositories on the system
+- Should be set once per repository, but rule ensures it's always current
+
+**Why set before each commit:**
+- Ensures configuration is always correct
+- Handles cases where repository is freshly cloned
+- Provides consistency across different environments
+- Low overhead to verify/set configuration
+</persistence>
+
+<troubleshooting>
+**If attribution still shows incorrectly:**
+
+1. **Check current config:**
+   ```bash
+   git config --list | grep user
+   ```
+
+2. **Verify SSH key association:**
+   - Ensure SSH key is associated with claude-hughes GitHub account
+   - Check authentication with `gh auth status`
+
+3. **Confirm commit details:**
+   ```bash
+   git show --format=fuller HEAD
+   ```
+
+4. **Re-set configuration if needed:**
+   ```bash
+   git config user.name "Claude Hughes"
+   git config user.email "doug+ai@doughughes.net"
+   ```
+</troubleshooting>

--- a/.claude/rules/git-main-always-pull-after-switching.rule.md
+++ b/.claude/rules/git-main-always-pull-after-switching.rule.md
@@ -1,0 +1,107 @@
+---
+applies_to:
+  - file_patterns: []
+  - contexts: ["git", "main", "pull", "workflow"]
+  - actions: ["after_switching_to_main"]
+timing: "after"
+summary: "Always pull latest changes after switching to main branch"
+version: "1.0.0"
+---
+
+# Rule: Always Pull After Switching to Main
+
+<purpose>
+This rule ensures that after switching to the main branch, Claude always pulls the latest changes from the remote repository to maintain an up-to-date local main branch and prevent conflicts or outdated code.
+</purpose>
+
+<instructions>
+IMMEDIATELY after switching to the main branch, you MUST:
+
+1. **Pull latest changes**: Run `git pull` 
+2. **Verify the pull**: Confirm the pull completed successfully
+3. **Ready for work**: Main branch is now up-to-date and ready for new work
+
+This ensures the main branch always reflects the latest remote state.
+</instructions>
+
+<workflow_steps>
+After executing `git checkout main` or switching to main:
+
+1. Run: `git pull`
+2. Verify: Check output for successful pull or "Already up to date"
+3. Ready: Main branch now has latest changes from remote
+</workflow_steps>
+
+<examples>
+<correct>
+Switching to main and pulling:
+```bash
+git checkout main
+git pull
+# Output: Already up to date. (or successful pull message)
+```
+
+After PR merge, switching back to main:
+```bash
+gh pr merge 5 --squash
+git checkout main
+git pull  # Gets the merged changes
+```
+</correct>
+
+<incorrect>
+Switching to main without pulling:
+```bash
+git checkout main
+# Starting work without pulling - VIOLATION
+```
+
+Forgetting to pull after checkout:
+```bash
+git checkout main
+# Immediately creating new branch without pull - VIOLATION
+git checkout -b feature/new-work
+```
+</incorrect>
+</examples>
+
+<timing>
+This rule applies:
+- AFTER successfully switching to main branch with `git checkout main`
+- AFTER any command that results in being on main branch
+- BEFORE starting any new work or creating branches from main
+</timing>
+
+<validation>
+After switching to main, verify:
+- [ ] Successfully switched to main branch
+- [ ] Ran `git pull` command
+- [ ] Pull completed successfully (no errors)
+- [ ] Main branch is now up-to-date with remote
+- [ ] Ready to proceed with next steps
+</validation>
+
+<pull_handling>
+**Successful pull scenarios:**
+- "Already up to date" - main was current
+- "Fast-forward" - pulled new commits successfully
+- "Merge made by..." - merged remote changes
+
+**Error scenarios require attention:**
+- Merge conflicts - resolve before proceeding
+- Network issues - retry or continue offline
+- Authentication issues - resolve auth problems
+
+**After successful pull:**
+- Main branch reflects latest remote state
+- Safe to create new branches
+- Safe to start new work cycles
+</pull_handling>
+
+<exceptions>
+Do NOT pull when:
+- Network is unavailable and user explicitly continues offline
+- User has explicitly requested to work with specific commit
+- Working in detached HEAD state intentionally
+- Git pull would cause conflicts and user requests manual handling
+</exceptions>

--- a/.claude/rules/git-workflow-always-switch-to-main-after-pr-merge.rule.md
+++ b/.claude/rules/git-workflow-always-switch-to-main-after-pr-merge.rule.md
@@ -1,0 +1,91 @@
+---
+applies_to:
+  - file_patterns: []
+  - contexts: ["git", "workflow", "pr", "merge"]
+  - actions: ["after_pr_merge"]
+timing: "after"
+summary: "Always switch back to main branch after successfully merging a PR"
+version: "1.0.0"
+---
+
+# Rule: Always Switch to Main After PR Merge
+
+<purpose>
+This rule ensures that after successfully merging a pull request, Claude automatically switches back to the main branch to maintain proper git workflow and prepare for future work on a clean main branch state.
+</purpose>
+
+<instructions>
+IMMEDIATELY after successfully merging any pull request, you MUST:
+
+1. **Switch to main branch**: Run `git checkout main`
+2. **Verify the switch**: Confirm you're on main with `git branch --show-current`
+3. **Clean up**: The feature branch can remain (user may delete it separately)
+
+This ensures you're always working from the latest main branch state after completing PR workflows.
+</instructions>
+
+<workflow_steps>
+After executing a successful PR merge (like `gh pr merge`):
+
+1. Run: `git checkout main`
+2. Verify: `git branch --show-current` should show "main"
+3. Ready for next work cycle on clean main branch
+</workflow_steps>
+
+<examples>
+<correct>
+After merging PR #5:
+```bash
+gh pr merge 5 --squash
+# PR merge successful
+git checkout main
+git branch --show-current  # Shows: main
+```
+
+After merging current branch's PR:
+```bash
+gh pr merge --squash
+# PR merge successful  
+git checkout main
+git branch --show-current  # Shows: main
+```
+</correct>
+
+<incorrect>
+Staying on feature branch after merge:
+```bash
+gh pr merge 3 --squash
+# PR merge successful
+# Still on feature/auth-system branch - VIOLATION
+```
+
+Forgetting to switch back:
+```bash
+gh pr merge --squash
+# Continuing work without switching to main - VIOLATION
+```
+</incorrect>
+</examples>
+
+<timing>
+This rule applies:
+- AFTER any successful PR merge operation
+- AFTER confirming the merge completed successfully
+- BEFORE starting any new work or file modifications
+</timing>
+
+<validation>
+After PR merge, verify:
+- [ ] PR merge command completed successfully
+- [ ] Switched to main branch with `git checkout main`
+- [ ] Confirmed on main with `git branch --show-current`
+- [ ] Ready to start fresh work from main branch
+</validation>
+
+<exceptions>
+Do NOT switch to main when:
+- PR merge failed or was cancelled
+- User explicitly requests to stay on current branch
+- Working on multiple related PRs that require staying on feature branch
+- User has explicitly checked out a different target branch
+</exceptions>

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,8 @@
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(git checkout:*)",
-      "WebFetch(domain:docs.github.com)"
+      "WebFetch(domain:docs.github.com)",
+      "Bash(git rebase:*)"
     ],
     "deny": []
   }


### PR DESCRIPTION
## Purpose

This PR fixes a command syntax error in the PR approval verification rule and adds workflow automation rules to improve both git workflow and PR management processes.

The main issues addressed are:
- Incorrect `gh pr status [PR-number]` command syntax that was causing errors
- Missing automation for switching back to main branch after PR merges  
- Missing automation for pulling latest changes when switching to main branch
- Missing automation for keeping PR descriptions current when new work is pushed
- Need for better verification step guidelines focusing on human-required testing

## Approach

**Fixed PR Status Command Syntax:**
- Updated `gh-pr-always-verify-approval-before-merge.rule.md` to use correct `gh pr view [PR-number]` instead of incorrect `gh pr status [PR-number]`
- Updated all examples and documentation to reflect proper command usage
- Added clarification that `gh pr status` takes no PR number argument

**Added Post-Merge Main Switch Rule:**
- Created `git-workflow-always-switch-to-main-after-pr-merge.rule.md` (v1.0.0)
- Ensures automatic return to main branch after successful PR merges
- Prevents staying on stale feature branches after merge completion
- Includes proper timing (after PR merge) and validation steps

**Added Main Branch Pull Rule:**
- Created `git-main-always-pull-after-switching.rule.md` (v1.0.0) 
- Automatically pulls latest changes when switching to main branch
- Keeps local main branch synchronized with remote repository
- Prevents conflicts and ensures latest code when starting new work

**Added PR Description Update Rule:**
- Created `gh-pr-always-update-description-after-new-commits.rule.md` (v1.0.0)
- Automatically evaluates if PR description needs updating after new commits are pushed
- Updates description only when new work changes scope, approach, or adds significant functionality  
- Preserves existing description when new commits are minor improvements
- Includes comprehensive evaluation criteria and maintains standard 5-section format

**Added Verification Steps Rule:**
- Created `gh-pr-verification-only-include-human-required-steps.rule.md` (v1.0.0)
- Ensures verification steps only include items requiring human interaction or judgment
- Excludes steps Claude can verify automatically (command syntax, file creation, rule indexing)
- Focuses on user-facing testing, production environment validation, and manual workflows
- Makes PR verification sections more meaningful and actionable for reviewers

## Additional Notes

All new rules follow the established patterns:
- Single responsibility principle compliance
- Standard YAML frontmatter with version 1.0.0
- Comprehensive examples and validation sections
- Proper timing and context specifications

The fixes address real command syntax errors that were occurring during PR merge workflows, while the new automation rules improve both git workflow efficiency and PR management quality.

## Open Questions

None - the implementation is complete and tested.

## Verification Steps

No manual verification required - all changes are internal rule definitions that are automatically testable and discoverable through the rule indexing system.